### PR TITLE
use a sane version number for the client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>1.0.1</revision>
+        <revision>4.4.2-1</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>


### PR DESCRIPTION
Use a version number that maps to the k8s client for sane versioning.