### PR TITLE
remove slf4j version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jul-to-slf4j</artifactId>
                 </exclusion>
+                <!-- provided by jenkins -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
         <java.level>8</java.level>
         <kubernetes-client.version>4.6.0</kubernetes-client.version>
         <jackson2-api.version>2.9.9</jackson2-api.version>
-        <slf4jVersion>1.7.26</slf4jVersion>
     </properties>
     <name>Kubernetes Client API Plugin</name>
     <description>This plugin provides the fabric8.io Kubernetes Client API to plugins.</description>


### PR DESCRIPTION
it was pointed out by @jtnord [here](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/pull/32#discussion_r329807758) that slf4-1.7.26

>  is a higher version that ships with jenkins and as such allows bugs to be introduced by depending on newer APIs that are available.
https://github.com/jenkinsci/jenkins/blob/jenkins-2.176.1/pom.xml#L94
If something needs this version then there is likely to be an incompatability somewhere at runtime

`fabric8.io:kubernetes-client:4.6.0` does have a dependency on slf4j-1.7.26, this change will downgrade it 1.7.25. Looking that [release notes](https://www.slf4j.org/news.html) it probably won't matter either way as I don't see the slf4j-ext module in the dependency tree.

@Vlatombe, the kubernetes-plugin sets the version to 1.7.26, is there a specific reason for that? I suspect it's to align with the fabric8 dependency.