### PR TITLE
Add bouncycastle-api jenkins plugin to be able to treat EC cluster keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
             <artifactId>jackson2-api</artifactId>
             <version>${jackson2-api.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+            <version>2.17</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Add bouncycastle-api jenkins plugin to be able to treat EC cluster keys

This will set Security.getProvider("BC") for kubernetes-client