### PR TITLE
 Bump revision from 4.13.2-2 to 5.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,10 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>kubernetes-client-api</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>5.4.1</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>5.2.1</revision>
-        <changelist>-beta-1-SNAPSHOT</changelist>
+        <revision>5.4.1</revision>
         <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <jackson2-api.version>2.12.1</jackson2-api.version>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Bumps kubernetes-client to version 5.4.1 which allows dependant plugins to use SharedInformer API.
The 5.4.x version contains also main bug fixes and performances improvements as well as better  connections lifecycle management.
https://groups.google.com/u/1/g/jenkinsci-dev/c/HumYSZBfRgk

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue



<!--
Put an `x` into the [ ] to show you have filled the information
-->
