### PR TITLE
Update parent POM, switch to Renovate, enable dep automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jenkins-infra/.github:renovate-config"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>jenkins-infra/.github:renovate-config"
+    "github>jenkinsci/renovate-config"
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>6.2108.v08c2b_01b_cf4d</version>
+        <version>6.2122.v70b_7b_f659d72</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Ensures that we pick up https://github.com/jenkinsci/plugin-pom/pull/1290 despite https://github.com/dependabot/dependabot-core/issues/14102.

This PR updates the plugin to:
- Use the latest parent POM version (6.2122.v70b_7b_f659d72)
- Switch from Dependabot to Renovate for dependency management, as in https://github.com/jenkinsci/archetypes/pull/886
- (Perhaps) enable GitHub Actions reusable workflows for dependency automerge, as in https://github.com/jenkins-infra/github-reusable-workflows/pull/48

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-66540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)